### PR TITLE
Update ghostwriter/coding-standard to version dev-main#894becb

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "0347d434a01e9215a2f1dee4d1e4b651e6f96fa3"
+                "reference": "894becbcf49518be5910d6d5835af5338a0c4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0347d434a01e9215a2f1dee4d1e4b651e6f96fa3",
-                "reference": "0347d434a01e9215a2f1dee4d1e4b651e6f96fa3",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/894becbcf49518be5910d6d5835af5338a0c4cf9",
+                "reference": "894becbcf49518be5910d6d5835af5338a0c4cf9",
                 "shasum": ""
             },
             "require": {
@@ -821,7 +821,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.1",
-                "phpunit/phpunit": "^12.3.14",
+                "phpunit/phpunit": "^12.3.15",
                 "symfony/var-dumper": "^7.3.4"
             },
             "default-branch": true,
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-27T13:40:07+00:00"
+            "time": "2025-09-28T12:43:23+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#0347d43` to `dev-main#894becb`.

This pull request changes the following file(s): 

- Update `composer.lock`