### PR TITLE
Update phpunit phar 12.5.4 to 12.5.5

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -8,6 +8,6 @@
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>
-  <phar name="phpunit" version="^12.5.4" installed="12.5.4" location="./tools/phar/phpunit" copy="true"/>
+  <phar name="phpunit" version="^12.5.5" installed="12.5.5" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.14.3" installed="6.14.3" location="./tools/phar/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Updates phpunit phar file from 12.5.4 to 12.5.5.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpunit`