### PR TITLE
Update ghostwriter/coding-standard to version dev-main#91c873c

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "459d0b70d8b229bb3ba104fc7bc1635b5da7deae"
+                "reference": "91c873c76d14f8b099fdd1530db7f93136380039"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/459d0b70d8b229bb3ba104fc7bc1635b5da7deae",
-                "reference": "459d0b70d8b229bb3ba104fc7bc1635b5da7deae",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/91c873c76d14f8b099fdd1530db7f93136380039",
+                "reference": "91c873c76d14f8b099fdd1530db7f93136380039",
                 "shasum": ""
             },
             "require": {
@@ -702,7 +702,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.5.6",
+                "phpunit/phpunit": "^12.5.7",
                 "symfony/process": "^8.0.3",
                 "symfony/var-dumper": "^8.0.3"
             },
@@ -818,7 +818,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-23T18:48:59+00:00"
+            "time": "2026-01-24T18:36:51+00:00"
         },
         {
             "name": "ghostwriter/console",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#459d0b7` to `dev-main#91c873c`.

This pull request changes the following file(s): 

- Update `composer.lock`