### PR TITLE
Update ghostwriter/coding-standard to version dev-main#46c1baf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^6.0.1",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.5.7",
+        "phpunit/phpunit": "^12.5.8",
         "symfony/var-dumper": "^8.0.4"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dac3bae5c608ce7f5f8c99bb175644f9",
+    "content-hash": "da334ea42e60ce8bd251a8c0f96bc217",
     "packages": [],
     "packages-dev": [
         {
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "c7a0b544b6f38cc46aca97645219a9eb5c907640"
+                "reference": "46c1baf495c61e48e6a9df09e3142a0e3ac37707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/c7a0b544b6f38cc46aca97645219a9eb5c907640",
-                "reference": "c7a0b544b6f38cc46aca97645219a9eb5c907640",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/46c1baf495c61e48e6a9df09e3142a0e3ac37707",
+                "reference": "46c1baf495c61e48e6a9df09e3142a0e3ac37707",
                 "shasum": ""
             },
             "require": {
@@ -818,7 +818,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-27T16:40:43+00:00"
+            "time": "2026-01-27T20:31:57+00:00"
         },
         {
             "name": "ghostwriter/console",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#c7a0b54` to `dev-main#46c1baf`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`