### PR TITLE
Update boundwize/structarmed to version 0.7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.1",
+        "boundwize/structarmed": "^0.7.4",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8fdcaa609a87bb9f1943d654ce270e7",
+    "content-hash": "fc8ca2abdede2f292b6f88a75588f1f9",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.1",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "125c5c1227e1ee27bb1edebb3a6f884d0eee973d"
+                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/125c5c1227e1ee27bb1edebb3a6f884d0eee973d",
-                "reference": "125c5c1227e1ee27bb1edebb3a6f884d0eee973d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9e3216565e7d6f55ea63fbe3ed6082117228887f",
+                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.4"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T15:58:05+00:00"
+            "time": "2026-05-21T23:57:28+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -148,16 +148,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "b94c956bf1098f932313f651ddabdbba9c1db9a0"
+                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b94c956bf1098f932313f651ddabdbba9c1db9a0",
-                "reference": "b94c956bf1098f932313f651ddabdbba9c1db9a0",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6a490267228b3bdd902bc716dc8cb787af69db03",
+                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.1",
+                "boundwize/structarmed": "^0.7.4",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -268,7 +268,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T17:42:02+00:00"
+            "time": "2026-05-22T02:16:14+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.1` to `0.7.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`