### PR TITLE
Update boundwize/structarmed to version 0.7.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.6",
+        "boundwize/structarmed": "^0.7.7",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "ghostwriter/testify": "^0.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34ab3f324f24b6747195b724e8d11d4d",
+    "content-hash": "e5917bcd2e51161031ca16f5583a5ec3",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.6",
+            "version": "0.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305"
+                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/27222c45da6e7c7a0eefac55c6e85359bdb29305",
-                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a050e463fc8f167896f0da257aaad007c7e7b98",
+                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.6"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.7"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-22T14:00:28+00:00"
+            "time": "2026-05-24T09:34:07+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -237,16 +237,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5074a7406f1a00758796840d0b581b79e868bb39"
+                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5074a7406f1a00758796840d0b581b79e868bb39",
-                "reference": "5074a7406f1a00758796840d0b581b79e868bb39",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
+                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.6",
+                "boundwize/structarmed": "^0.7.7",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -357,7 +357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-24T03:53:55+00:00"
+            "time": "2026-05-24T10:24:09+00:00"
         },
         {
             "name": "ghostwriter/console",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.6` to `0.7.7`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`