### PR TITLE
Update boundwize/structarmed to version 0.7.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.7",
+        "boundwize/structarmed": "^0.7.10",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "ghostwriter/testify": "^0.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5917bcd2e51161031ca16f5583a5ec3",
+    "content-hash": "daad0d37d724af03dcc8a1eb17142b0b",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.7",
+            "version": "0.7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98"
+                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a050e463fc8f167896f0da257aaad007c7e7b98",
-                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
+                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.7"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-24T09:34:07+00:00"
+            "time": "2026-05-25T12:23:38+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -237,16 +237,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4"
+                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
-                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/afececade2eef113f1d76cefdf06d33ca660b86f",
+                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.7",
+                "boundwize/structarmed": "^0.7.9",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -357,7 +357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-24T10:24:09+00:00"
+            "time": "2026-05-25T11:40:02+00:00"
         },
         {
             "name": "ghostwriter/console",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.7` to `0.7.10`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`