### PR TITLE
Update boundwize/structarmed to version 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.12",
+        "boundwize/structarmed": "^0.8.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.2",
         "ghostwriter/phpunit-assertions": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3f353d4fb7af31a59e5a3e32e11b7bb",
+    "content-hash": "2c2987037f785d9219d7ee6de70b8698",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.12",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "4932aa4d395e6ddf7dd372f8bf85a41213715bdf"
+                "reference": "313a9d05146755160a10ad6c0b82393cb91abaeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4932aa4d395e6ddf7dd372f8bf85a41213715bdf",
-                "reference": "4932aa4d395e6ddf7dd372f8bf85a41213715bdf",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/313a9d05146755160a10ad6c0b82393cb91abaeb",
+                "reference": "313a9d05146755160a10ad6c0b82393cb91abaeb",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.12"
+                "source": "https://github.com/boundwize/structarmed/tree/0.8.0"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T14:14:49+00:00"
+            "time": "2026-05-27T10:31:50+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.12` to `0.8.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`